### PR TITLE
Use human readable date on pico log headers

### DIFF
--- a/Templates/List_templates.html
+++ b/Templates/List_templates.html
@@ -20,7 +20,7 @@
 
 <div id="logitem-template" style="display:none;">
    <div id="{{id}}" data-role="collapsible" data-theme="a" data-content-theme="b">
-   <h4>{{timestamp}} ({{eid}})</h4>
+   <h4>{{formatDate timestamp}} ({{eid}})</h4>
         {{#each log_items}}
 	 {{#ifDivider this }}
 	   <span style="color:blue">{{this}}</span> 

--- a/js/app.js
+++ b/js/app.js
@@ -626,7 +626,7 @@
 	if (!("formatDate" in Handlebars.helpers)) {
 		Handlebars.registerHelper("formatDate", function(datetime) {
 			// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
-			return datetime.toLocaleString();
+			return new Date(datetime).toLocaleString();
 		});
 	}
 	// Handlebar templates compiled at load time to create functions

--- a/js/app.js
+++ b/js/app.js
@@ -629,6 +629,7 @@
 			return new Date(datetime).toLocaleString();
 		});
 	}
+	
 	// Handlebar templates compiled at load time to create functions
 	// templates are included to index.html from Templates directory.
 	//confirm_channel_remove

--- a/js/app.js
+++ b/js/app.js
@@ -622,14 +622,6 @@
 		}
 	);
 
-	// Register a formatDate hanblebars helper, but only once.
-	if (!("formatDate" in Handlebars.helpers)) {
-		Handlebars.registerHelper("formatDate", function(datetime) {
-			// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
-			return new Date(datetime).toLocaleString();
-		});
-	}
-	
 	// Handlebar templates compiled at load time to create functions
 	// templates are included to index.html from Templates directory.
 	//confirm_channel_remove
@@ -675,12 +667,21 @@
 			}); // this will go to the authorization page.
 		});
 
-		Handlebars.registerHelper('ifDivider', function(v1, options) {
-		 if(v1.match(/-----\*\*\*----/)) {
-			return options.fn(this);
-		 }
-			return options.inverse(this);
-		 });
+		Handlebars.registerHelper({
+
+			ifDivider: function(v1, options) {
+		 		if(v1.match(/-----\*\*\*----/)) {
+					return options.fn(this);
+		 		}
+				return options.inverse(this);
+		 	},
+
+		 	formatDate: function(datetime) {
+				// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
+				return new Date(datetime).toLocaleString();
+			}
+			
+		});
 
 		console.log("Choose page to show");
 

--- a/js/app.js
+++ b/js/app.js
@@ -623,7 +623,7 @@
 	);
 
 	// Register a formatDate hanblebars helper, but only once.
-	if (!"formatDate" in Handlebars.helpers) {
+	if (!("formatDate" in Handlebars.helpers)) {
 		Handlebars.registerHelper("formatDate", function(datetime) {
 			// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
 			return datetime.toLocaleString();

--- a/js/app.js
+++ b/js/app.js
@@ -85,6 +85,8 @@
 			}, 
 			
 			home: function(type, match, ui, page) {
+                // Check if handlebars is defined.
+                console.log(typeof Handlebars);
 				console.log("home Handler");
 				$.mobile.loading("hide");
 			},

--- a/js/app.js
+++ b/js/app.js
@@ -85,8 +85,9 @@
 			}, 
 			
 			home: function(type, match, ui, page) {
-                // Check if handlebars is defined.
-                console.log(typeof Handlebars);
+				Handlebars.registerHelper("formatDate", function(datetime) {
+
+				});
 				console.log("home Handler");
 				$.mobile.loading("hide");
 			},

--- a/js/app.js
+++ b/js/app.js
@@ -85,13 +85,6 @@
 			}, 
 			
 			home: function(type, match, ui, page) {
-				// Register a formatDate hanblebars helper, but only once.
-				if (!"formatDate" in Handlebars.helpers) {
-					Handlebars.registerHelper("formatDate", function(datetime) {
-						// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
-						return datetime.toLocaleString();
-					});
-				}
 				console.log("home Handler");
 				$.mobile.loading("hide");
 			},
@@ -629,6 +622,13 @@
 		}
 	);
 
+	// Register a formatDate hanblebars helper, but only once.
+	if (!"formatDate" in Handlebars.helpers) {
+		Handlebars.registerHelper("formatDate", function(datetime) {
+			// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
+			return datetime.toLocaleString();
+		});
+	}
 	// Handlebar templates compiled at load time to create functions
 	// templates are included to index.html from Templates directory.
 	//confirm_channel_remove

--- a/js/app.js
+++ b/js/app.js
@@ -85,9 +85,13 @@
 			}, 
 			
 			home: function(type, match, ui, page) {
-				Handlebars.registerHelper("formatDate", function(datetime) {
-
-				});
+				// Register a formatDate hanblebars helper, but only once.
+				if (!"formatDate" in Handlebars.helpers) {
+					Handlebars.registerHelper("formatDate", function(datetime) {
+						// For now just be cheap and lazy and use .toLocaleString(). We can get even fancier later.
+						return datetime.toLocaleString();
+					});
+				}
 				console.log("home Handler");
 				$.mobile.loading("hide");
 			},


### PR DESCRIPTION
This makes the date on pico log entry headers a little more readable by adding a handlebars helper named `formatDate`.

You can now call `{{formatDate yourDateTimeString}}` in any handlebar template.
