### PR TITLE
picolab should use its own devtools-api.js

### DIFF
--- a/_layouts/code.html
+++ b/_layouts/code.html
@@ -54,7 +54,7 @@
   <script src="https://code.jquery.com/mobile/1.4.2/jquery.mobile-1.4.2.min.js"></script>
   <script src="js/handlebars-v1.3.0.js"></script>
   <!--getting access for devtools-api-->
-  <script src="https://rawgit.com/kre/devtools/gh-pages/js/devtools-api.js"></script>
+  <script src="https://rawgit.com/Picolab/devtools/gh-pages/js/devtools-api.js"></script>
   <script src="https://rawgit.com/Picolab/wrangler/master/js/wrangler.js"></script>
   <script src="js/wrangler-config.js"></script>
   <script src="js/moment.js"></script>


### PR DESCRIPTION
picolab should not use devtools-api.js from kre.
