### PR TITLE
new bootstrap/devtools rids

### DIFF
--- a/appPages/install-rulesets.html
+++ b/appPages/install-rulesets.html
@@ -29,7 +29,7 @@
 	      <form id="form-install-ruleset">
 	        <div data-role="fieldcontain">
    	          <label for="rid">Ruleset ID:</label>
-		  <input type="text" name="rid" id="rid" value="" placeholder="b507199x1.prod" />
+		  <input type="text" name="rid" id="rid" value="" placeholder="b507199x13.prod" />
 		</div>
 	      </form>
 	      <div>

--- a/appPages/oAuth-client-registration.html
+++ b/appPages/oAuth-client-registration.html
@@ -44,7 +44,7 @@
               <label for="client_info_page_url">info page url:</label>
       <input type="text" name="client_info_page_url" id="client_info_page_url" value="" placeholder="http://www.example.com/info" />
               <label for="client_bootstrapRids">bootstrap Rids:</label>
-      <input type="text" name="client_bootstrapRids" id="client_bootstrapRids" value="" placeholder="ex: v1_wrangler.prod, b507199x1.prod" />
+      <input type="text" name="client_bootstrapRids" id="client_bootstrapRids" value="" placeholder="ex: v1_wrangler.prod, b507199x13.prod" />
 		</div>
 	      </form>
 	      <div>

--- a/js/devtools-api.js
+++ b/js/devtools-api.js
@@ -14,11 +14,11 @@
 	get_rid : function(name) {
         
         var rids = {
-            "rulesets": {"prod": "b507199x0.prod", 
-                          "dev": "b507199x0.dev"
+            "rulesets": {"prod": "b507199x14.prod", 
+                          "dev": "b507199x14.dev"
             },
-            "bootstrap":{"prod": "b507199x1.prod", 
-                          "dev": "b507199x1.dev"
+            "bootstrap":{"prod": "b507199x13.prod", 
+                          "dev": "b507199x13.dev"
             }
         };
 
@@ -59,11 +59,11 @@
 		checkForBootstrapped = function(justNeedsBootstrap, needsBootstrapRuleset) {
             return wrangler.bootstrapCheck(function(json) {
 				console.log(json);
-				if ($.inArray('b507199x0.dev', json.rids) > -1 && $.inArray('v1_wrangler.dev', json.rids) > -1) {
+				if ($.inArray('b507199x14.dev', json.rids) > -1 && $.inArray('v1_wrangler.dev', json.rids) > -1) {
 					console.log("Pico is bootstrapped");
 					cb();
 				}
-				else if ($.inArray('b507199x1.dev', json.rids) > -1) { // will never make it here ...
+				else if ($.inArray('b507199x13.dev', json.rids) > -1) { // will never make it here ...
 					justNeedsBootstrap();
 				}
 				else {

--- a/ruleSets/bootstrap_dev.krl
+++ b/ruleSets/bootstrap_dev.krl
@@ -1,4 +1,4 @@
-//for flushing: http://cs.kobj.net/ruleset/flush/b507199x1.prod;b507199x1.dev
+//for flushing: http://cs.kobj.net/ruleset/flush/b507199x13.prod;b507199x13.dev
 ruleset DevTools_bootstrap {
     meta {
         name "DevTools Bootstrap"
@@ -7,7 +7,7 @@ ruleset DevTools_bootstrap {
         >>
 
        // use module a169x625 alias CloudOS
-        use module b16x24 alias system_credentials
+        use module b16x42 alias system_credentials
 
         logging on
         
@@ -22,7 +22,7 @@ ruleset DevTools_bootstrap {
             "core": [
                    "a169x676.prod",  // PDS
                    "a16x129.dev",    // SendGrid module
-                   "b507199x0.dev", //DevTools
+                   "b507199x14.dev", //DevTools
                    "b16x29.prod"     // logging
             ],
       "unwanted": []
@@ -72,16 +72,16 @@ ruleset DevTools_bootstrap {
 
         bootstrapped = installed_rids{"rids"}
                          .klog(">>>> pico installed_rids before filter >>>> ")
-                         .filter(function(v){v eq "b507199x0.dev"})
+                         .filter(function(v){v eq "b507199x14.dev"})
                          .klog(">>>> pico installed_rids after filter >>>> ")
                          .length()
                          .klog(">>>> pico installed_rids length >>>> ")
-                         ;// check if installed_rids includes b507199x0.prod --- use a filter and check if length is > 0.
+                         ;// check if installed_rids includes b507199x14.prod --- use a filter and check if length is > 0.
       
       }
       if (bootstrapped > 1 ) then
       {
-        send_directive("found_b507199x0.dev_for_developer") 
+        send_directive("found_b507199x14.dev_for_developer") 
            with eci = eci;
       }
       fired {
@@ -91,8 +91,8 @@ ruleset DevTools_bootstrap {
         log ">>>> pico needs a bootstrap >>>> ";
         log ">>>> pico installed_rids, saw : " + rids.encode();
         log ">>>> pico installed_rids, saw : " + rids_string;
-        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x0.dev}), saw : " + installed_rids.filter(function(k,v){v eq "b507199x0.dev"}).encode();
-        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x0.dev}).length();, saw : " + installed_rids.filter(function(k,v){v eq "b507199x0.dev"}).length();
+        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x14.dev}), saw : " + installed_rids.filter(function(k,v){v eq "b507199x14.dev"}).encode();
+        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x14.dev}).length();, saw : " + installed_rids.filter(function(k,v){v eq "b507199x14.dev"}).length();
         raise explicit event devtools_bootstrap_needed ;  // don't bootstrap everything
         
       }
@@ -120,7 +120,7 @@ ruleset DevTools_bootstrap {
 		select when bootstrap bootstrap_rid_needed_on_child
 		pre {
 			target_pico = event:attr("target");
-			installed = InstallRulesets(["b507199x1.dev"], target_pico)
+			installed = InstallRulesets(["b507199x13.dev"], target_pico)
 								.defaultsTo("error","installing bootstrap");
 		}
 		{

--- a/ruleSets/bootstrap_prod.krl
+++ b/ruleSets/bootstrap_prod.krl
@@ -1,4 +1,4 @@
-//for flushing: http://cs.kobj.net/ruleset/flush/b507199x1.prod;b507199x1.dev
+//for flushing: http://cs.kobj.net/ruleset/flush/b507199x13.prod;b507199x13.dev
 ruleset DevTools_bootstrap {
     meta {
         name "DevTools Bootstrap"
@@ -7,7 +7,7 @@ ruleset DevTools_bootstrap {
         >>
 
        // use module a169x625 alias CloudOS
-        use module b16x24 alias system_credentials
+        use module b16x42 alias system_credentials
 
         logging on
         
@@ -22,7 +22,7 @@ ruleset DevTools_bootstrap {
             "core": [
                    "a169x676.prod",  // PDS
                    "a16x129.dev",    // SendGrid module
-                   "b507199x0.dev", //DevTools
+                   "b507199x14.dev", //DevTools
                    "b16x29.prod"     // logging
             ],
       "unwanted": []
@@ -72,16 +72,16 @@ ruleset DevTools_bootstrap {
 
         bootstrapped = installed_rids{"rids"}
                          .klog(">>>> pico installed_rids before filter >>>> ")
-                         .filter(function(v){v eq "b507199x0.dev"})
+                         .filter(function(v){v eq "b507199x14.dev"})
                          .klog(">>>> pico installed_rids after filter >>>> ")
                          .length()
                          .klog(">>>> pico installed_rids length >>>> ")
-                         ;// check if installed_rids includes b507199x0.prod --- use a filter and check if length is > 0.
+                         ;// check if installed_rids includes b507199x14.prod --- use a filter and check if length is > 0.
       
       }
       if (bootstrapped > 1 ) then
       {
-        send_directive("found_b507199x0.dev_for_developer") 
+        send_directive("found_b507199x14.dev_for_developer") 
            with eci = eci;
       }
       fired {
@@ -91,8 +91,8 @@ ruleset DevTools_bootstrap {
         log ">>>> pico needs a bootstrap >>>> ";
         log ">>>> pico installed_rids, saw : " + rids.encode();
         log ">>>> pico installed_rids, saw : " + rids_string;
-        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x0.dev}), saw : " + installed_rids.filter(function(k,v){v eq "b507199x0.dev"}).encode();
-        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x0.dev}).length();, saw : " + installed_rids.filter(function(k,v){v eq "b507199x0.dev"}).length();
+        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x14.dev}), saw : " + installed_rids.filter(function(k,v){v eq "b507199x14.dev"}).encode();
+        log ">>>> pico installed_rids.filter(function(k,v){v eq b507199x14.dev}).length();, saw : " + installed_rids.filter(function(k,v){v eq "b507199x14.dev"}).length();
         raise explicit event devtools_bootstrap_needed ;  // don't bootstrap everything
         
       }
@@ -120,7 +120,7 @@ ruleset DevTools_bootstrap {
     select when bootstrap bootstrap_rid_needed_on_child
     pre {
       target_pico = event:attr("target");
-      installed = InstallRulesets(["b507199x1.dev"], target_pico)
+      installed = InstallRulesets(["b507199x13.dev"], target_pico)
                 .defaultsTo("error","installing bootstrap");
     }
     {

--- a/ruleSets/devtools_dev.krl
+++ b/ruleSets/devtools_dev.krl
@@ -1,5 +1,5 @@
-//b507199x0
-//Flush the ruleset webpage: http://cs.kobj.net/ruleset/flush/b507199x0.prod;b507199x0.dev
+//b507199x14
+//Flush the ruleset webpage: http://cs.kobj.net/ruleset/flush/b507199x14.prod;b507199x14.dev
 ruleset devtools {
   meta {
     name "DevTools"
@@ -8,7 +8,7 @@ ruleset devtools {
     >>
         author "KRL-DevTools Developer"
 
-        use module b16x24 alias system_credentials
+        use module b16x42 alias system_credentials
 
 
         logging on

--- a/ruleSets/devtools_prod.krl
+++ b/ruleSets/devtools_prod.krl
@@ -1,5 +1,5 @@
-//b507199x0
-//Flush the ruleset webpage: http://cs.kobj.net/ruleset/flush/b507199x0.prod;b507199x0.dev
+//b507199x14
+//Flush the ruleset webpage: http://cs.kobj.net/ruleset/flush/b507199x14.prod;b507199x14.dev
 ruleset devtools {
   meta {
     name "DevTools"
@@ -8,7 +8,7 @@ ruleset devtools {
     >>
         author "KRL-DevTools Developer"
 
-        use module b16x24 alias system_credentials
+        use module b16x42 alias system_credentials
 
 
         logging on


### PR DESCRIPTION
this will update picolab/devtools to use new bootstrap and devtools rulesets so that changes to kre/devtools rulesets won’t effect production devtools website. 
WARNING!!! IF B16X42 DOES NOT GIVE b507199x13 AND b507199x14 CREDENTIALS, THIS PULL WILL BREAK THE WEBSITE. further testing of listing registered rulesets will expose failure from this pull.

<!---
@huboard:{"order":0.005613269492103286,"milestone_order":116,"custom_state":"archived"}
-->
