### PR TITLE
use v1_devtools_bootstrap

### DIFF
--- a/appPages/oAuth-client-registration.html
+++ b/appPages/oAuth-client-registration.html
@@ -44,7 +44,7 @@
               <label for="client_info_page_url">info page url:</label>
       <input type="text" name="client_info_page_url" id="client_info_page_url" value="" placeholder="http://www.example.com/info" />
               <label for="client_bootstrapRids">bootstrap Rids:</label>
-      <input type="text" name="client_bootstrapRids" id="client_bootstrapRids" value="" placeholder="ex: v1_wrangler.prod, b507199x13.prod" />
+      <input type="text" name="client_bootstrapRids" id="client_bootstrapRids" value="" placeholder="ex: v1_wrangler.prod, v1_devtools_bootstrap.prod" />
 		</div>
 	      </form>
 	      <div>

--- a/js/devtools-api.js
+++ b/js/devtools-api.js
@@ -17,8 +17,8 @@
             "rulesets": {"prod": "b507199x14.prod", 
                           "dev": "b507199x14.prod"
             },
-            "bootstrap":{"prod": "b507199x13.prod", 
-                          "dev": "b507199x13.prod"
+            "bootstrap":{"prod": "v1_devtools_bootstrap.prod", 
+                          "dev": "v1_devtools_bootstrap.prod"
             }
         };
 
@@ -63,7 +63,7 @@
 					console.log("Pico is bootstrapped");
 					cb();
 				}
-				else if ($.inArray('b507199x13.prod', json.rids) > -1) { // will never make it here ...
+				else if ($.inArray('v1_devtools_bootstrap.prod', json.rids) > -1) { // will never make it here ...
 					justNeedsBootstrap();
 				}
 				else {

--- a/ruleSets/bootstrap_prod.krl
+++ b/ruleSets/bootstrap_prod.krl
@@ -1,4 +1,4 @@
-//for flushing: http://cs.kobj.net/ruleset/flush/b507199x13.prod;b507199x13.dev
+//for flushing: http://cs.kobj.net/ruleset/flush/v1_devtools_bootstrap.prod;v1_devtools_bootstrap.dev
 ruleset DevTools_bootstrap {
     meta {
         name "DevTools Bootstrap"
@@ -121,7 +121,7 @@ ruleset DevTools_bootstrap {
     select when bootstrap bootstrap_rid_needed_on_child
     pre {
       target_pico = event:attr("target");
-      installed = InstallRulesets(["b507199x13.prod"], target_pico)
+      installed = InstallRulesets(["v1_devtools_bootstrap.prod"], target_pico)
                 .defaultsTo("error","installing bootstrap");
     }
     {


### PR DESCRIPTION
devtools will now use v1_devtools_bootstrap. this will only solve
problems if the kre client key is updated to install
v1_devtools_bootstrap.
